### PR TITLE
Adding Torque Sensor on ADC1, replacing Temperature, improving shutdown

### DIFF
--- a/launch/hw_control.launch
+++ b/launch/hw_control.launch
@@ -1,6 +1,6 @@
 <launch>
    
-    <arg name="use_lidar" default="false"/>
+    <!-- <arg name="use_lidar" default="false"/> -->
     <!-- Load robot model -->
     <param name="robot_description"
        command="$(find xacro)/xacro --inorder '$(find trikey_description)/urdf/urdf_generator/robot.urdf.xacro'"/>
@@ -18,10 +18,12 @@
     -->
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>    
 
-    <group if="$(arg use_lidar)">
+    <!-- <group if="$(arg use_lidar)"> -->
         <!-- Load lidar -->
-        <include file="$(find rplidar_ros)/launch/rplidar.launch"/>
-    </group>
+        <!-- <include file="$(find rplidar_ros)/launch/rplidar.launch"/> -->
+    <!-- </group> -->
+
+    
     <!-- This will publish out /tf_static -->
 
 

--- a/src/bumpybot_hw_interface.cpp
+++ b/src/bumpybot_hw_interface.cpp
@@ -193,6 +193,13 @@ namespace bumpybot_hw
       ec_send_processdata();
       wkc = ec_receive_processdata(EC_TIMEOUTRET);
       }
+      exit(SIGINT); // this is a bad idea 
+      // A single attempt to shutdown the motors is made, and the program terminates irregarless of the outcome
+      // The above is bad practice,
+      //  but solves the issue of the program hanging when trying shutdown the rosnode
+
+      // In testing, there has not been any issue with the motors not shutting down, and in practice, the Estop would've been used to stop the motors in an emergency
+
 
       // ROS_INFO("Servo commanded to shut down");
       // check that the servo shut down

--- a/src/bumpybot_hw_interface.cpp
+++ b/src/bumpybot_hw_interface.cpp
@@ -544,7 +544,7 @@ static int everest_setup(uint16 slave)
 
 
   // Enable mapping by setting SubIndex 0x00 to the number of mapped objects. (0x1600 RPDO1 mapping parameter).
-  dType_32 = 0x00000007;
+  dType_32 = 0x00000008;
   wkc += everest_write32 (slave, 0x1A00, 0x00, dType_32);
 
   // Assign mapping to SM2
@@ -555,9 +555,9 @@ static int everest_setup(uint16 slave)
   wkc += everest_write16 (slave, 0x1C13, 1, 0x1A00);
   wkc += everest_write16 (slave, 0x1C13, 0, 1);
 
-  if (wkc != 21)
+  if (wkc != 22)
   {
-    printf(" TXPDO not configured correctly, Expected wkc: 21, got: %d\n", (wkc - 2));
+    printf(" TXPDO not configured correctly, Expected wkc: 22, got: %d\n", (wkc - 2));
     return -1;
   }
 

--- a/src/bumpybot_hw_interface.cpp
+++ b/src/bumpybot_hw_interface.cpp
@@ -316,21 +316,23 @@ namespace bumpybot_hw
       joint_effort_[i] = torque_f;
       js_msg.effort[i] = joint_effort_[i];
 
-      // Read temperature
-      int32_t temp_low = *(ec_slave[i+1].inputs + 17);
-      int32_t temp_med_low = *(ec_slave[i+1].inputs + 18);
-      int32_t temp_med_high = *(ec_slave[i+1].inputs + 19);
-      int32_t temp_high = *(ec_slave[i+1].inputs + 20);
-      int32_t temp = (temp_high << 24) | (temp_med_high << 16) | (temp_med_low << 8) | (temp_low);
-      float temp_f = ((union convIntToFloat){.i32 = temp}).f32;
-      temp_msg.position[i] = temp_f;
+//Temperature Commented out, replaced with torque sensor value from ADC
+// Leaving both in causes memory/packet timing issues (replaced one 32bit value with another)
+      // Read temperature 
+      // int32_t temp_low = *(ec_slave[i+1].inputs + 17);
+      // int32_t temp_med_low = *(ec_slave[i+1].inputs + 18);
+      // int32_t temp_med_high = *(ec_slave[i+1].inputs + 19);
+      // int32_t temp_high = *(ec_slave[i+1].inputs + 20);
+      // int32_t temp = (temp_high << 24) | (temp_med_high << 16) | (temp_med_low << 8) | (temp_low);
+      // float temp_f = ((union convIntToFloat){.i32 = temp}).f32;
+      // temp_msg.position[i] = temp_f;
 //      temp_msg.value_in_C[i] = temp_f;
 
-       // Torque sensor value
-      int32_t torque_sensor_low = *(ec_slave[i+1].inputs + 21);
-      int32_t torque_sensor_med_low = *(ec_slave[i+1].inputs + 22);
-      int32_t torque_sensor_med_high = *(ec_slave[i+1].inputs + 23);
-      int32_t torque_sensor_high = *(ec_slave[i+1].inputs + 24);
+       // Torque sensor (ADC) value
+      int32_t torque_sensor_low = *(ec_slave[i+1].inputs + 17);
+      int32_t torque_sensor_med_low = *(ec_slave[i+1].inputs + 18);
+      int32_t torque_sensor_med_high = *(ec_slave[i+1].inputs + 19);
+      int32_t torque_sensor_high = *(ec_slave[i+1].inputs + 20);
       int32_t torque_volts = (torque_sensor_high << 24) | (torque_sensor_med_high << 16) | (torque_sensor_med_low << 8) | (torque_sensor_low);
       float torque_sens_f = ((union convIntToFloat){.i32 = torque_volts}).f32;
       torque_sensor_msg.position[i] = torque_sens_f;
@@ -556,24 +558,24 @@ static int everest_setup(uint16 slave)
 
   // Subindex 7
   // Power Stage temperateure 1 - value
-  dType_32 = 0x20610020;
-  wkc += everest_write32 (slave, 0x1A00, 0x07, dType_32);
- osal_usleep(200);
+  // dType_32 = 0x20610020;
+  // wkc += everest_write32 (slave, 0x1A00, 0x07, dType_32);
+//  osal_usleep(200);
 
   // Subindex 8
   // Analog input 1 - value
   dType_32 = 0x20820020;
-  wkc += everest_write32 (slave, 0x1A00, 0x08, dType_32);
+  wkc += everest_write32 (slave, 0x1A00, 0x07, dType_32);
   osal_usleep(200);
 
-  // Subindex 9
+  // Subindex 9   
  // Analog input 1 - counts
- dType_32 = 0x20810010;
- wkc += everest_write32 (slave, 0x1A00, 0x09, dType_32);
- osal_usleep(200);
+//  dType_32 = 0x20810010;
+//  wkc += everest_write32 (slave, 0x1A00, 0x08, dType_32);
+//  osal_usleep(200);
 
   // Enable mapping by setting SubIndex 0x00 to the number of mapped objects. (0x1600 RPDO1 mapping parameter).
-  dType_32 = 0x00000009;
+  dType_32 = 0x00000007;
   wkc += everest_write32 (slave, 0x1A00, 0x00, dType_32);
 
   // Assign mapping to SM2
@@ -584,9 +586,9 @@ static int everest_setup(uint16 slave)
   wkc += everest_write16 (slave, 0x1C13, 1, 0x1A00);
   wkc += everest_write16 (slave, 0x1C13, 0, 1);
 
-  if (wkc != 22)
+  if (wkc != 20)
   {
-    printf(" TXPDO not configured correctly, Expected wkc: 22, got: %d\n", (wkc));
+    printf(" TXPDO not configured correctly, Expected wkc: 20, got: %d\n", (wkc));
     return -1;
   }
 

--- a/src/bumpybot_hw_interface.cpp
+++ b/src/bumpybot_hw_interface.cpp
@@ -555,9 +555,9 @@ static int everest_setup(uint16 slave)
   wkc += everest_write16 (slave, 0x1C13, 1, 0x1A00);
   wkc += everest_write16 (slave, 0x1C13, 0, 1);
 
-  if (wkc != 22)
+  if (wkc != 21)
   {
-    printf(" TXPDO not configured correctly, Expected wkc: 22, got: %d\n", (wkc - 2));
+    printf(" TXPDO not configured correctly, Expected wkc: 21, got: %d\n", (wkc - 2));
     return -1;
   }
 


### PR DESCRIPTION
### Adding Torque Sensor on ADC1
- Memory(?) bug found that limited data packet size when adding the ADC's 32bit float value as an input.
- Resolved by replacing Temperature (also a 32bit Float)
    Identified a memory (?) bug that limited the data packet size when adding the ADC’s 32-bit float value as an input.
    Resolved the issue by replacing the temperature value (also a 32-bit float) with the torque sensor reading.

### Improving Shutdown
- Motors are now correctly commanded to shut down when the node closes (e.g., via Ctrl+C).
- Improved the speed of node closure by calling exit(SIGINT); after shutting off the motors.
- Note: Calling exit(SIGINT); immediately after commanding the motors to shut down is a bad practice, as it forces the program to terminate regardless of the motors' response. However, this workaround prevents the program from hanging during shutdown.
    In testing, no issues were observed with the motors failing to shut down. In an actual emergency, the E-stop would be used to cut power to the motors.